### PR TITLE
feat: add a new type of target named `grouped_command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ As of this writing, the three types of targets are `simple`, `template` and `com
   If multiple paths trigger a `template` pipeline, it is triggered once for each path (subject to `path_processor` alterations, detailed below).
 
 * A `command` target is one that invokes a command once for each path (subject to the `path_processor` alterations, detailed below) and is expected to generate pipelines and pass them to `buildkite-agent pipeline upload` itself.
-  This command type is by far the most flexible and allows for truly devious pipelines to be created.
 
-As mentioned above, `template` and `command` targets are, by default, invoked once for each modified file.
+* A `grouped_command` target is one that invokes a command once with all the paths grouped together (subject to the `path_processor` alterations, detailed below). Similar to the `command` target, this is also expected to generate pipelines and pass them to the `buildkite-agent pipeline upload` itself.
+  This target type is by far the most flexible and allows for truly devious pipelines to be created.
+
+As mentioned above, `template` and `command` targets are, by default, invoked once for each modified file, and the `grouped_command` target is, by default, invoked once for an array of all the modified files.
 To control this behavior, the user may provide a `path_processor` argument to munge the paths in an intelligent way.
 By default, `forerunner` uses the `per-file` path processor to template the pipeline once for each file modified.
 However, some pipelines may wish to run upon the directories containing all modified files, or may wish to run once per overall project in a large monorepo.
@@ -59,4 +61,11 @@ steps:
           path_processor: per-file
           target: .buildkite/commands/create_update_project_pipeline.sh
           target_type: command
+      - staticfloat/forerunner:
+          # This will run an arbitrary command targeting a group consisting of all the files modified
+          watch:
+            - "**/*/Project.toml"
+          path_processor: per-file
+          target: .buildkite/commands/collate_and_trigger_pipeline.sh
+          target_type: grouped_command
 ```

--- a/hooks/command
+++ b/hooks/command
@@ -22,7 +22,7 @@ fi
 
 # Check for valid `target_type`
 case "${TARGET_TYPE}" in
-    simple | template | command)
+    simple | template | command | grouped_command)
         ;;
     *)
         echo "ERROR: Invalid target_type value '${TARGET_TYPE}'" >&2
@@ -131,4 +131,10 @@ if [[ "${TARGET_TYPE}" == "command" ]]; then
         echo "Triggering command pipeline ${TARGET} '${PP_PATH}'"
         ${TARGET} "${PP_PATH}"
     done
+fi
+
+# And for a "grouped_command" target, we'll simply pass on the list of all the files changed and let the command take care of uploading the pipeline.
+if [[ "${TARGET_TYPE}" == "grouped_command" ]]; then
+    echo "Triggering grouped command pipeline ${TARGET} for '${MATCHED_FILES[@]}'"
+    ${TARGET} "${MATCHED_FILES[@]}"
 fi


### PR DESCRIPTION
Add a new target, `grouped_command`, which would simply pass the list of all paths matched by the path-processor to the target pipeline. This would allow us to create more efficient (and complex) pipelines, specifically in the context of downstream testing in monorepos.